### PR TITLE
Lock namespace when destroying it or swapping its config

### DIFF
--- a/bucket.go
+++ b/bucket.go
@@ -89,6 +89,8 @@ func (ns *namespace) removeBucket(bucketName string) {
 
 // destroy calls Destroy() on all buckets in this namespace
 func (ns *namespace) destroy() {
+	ns.Lock()
+	defer ns.Unlock()
 	if ns.defaultBucket != nil {
 		ns.defaultBucket.Destroy()
 	}
@@ -96,6 +98,13 @@ func (ns *namespace) destroy() {
 	for _, bucket := range ns.buckets {
 		bucket.Destroy()
 	}
+}
+
+// swapCfg swaps the bucket config for the namespace.
+func (ns *namespace) swapCfg(newCfg *pbconfig.NamespaceConfig) {
+	ns.Lock()
+	defer ns.Unlock()
+	ns.cfg = newCfg
 }
 
 // BucketFactory creates buckets.

--- a/server.go
+++ b/server.go
@@ -276,7 +276,7 @@ func (s *server) updateBucketContainer(newConfig *pb.ServiceConfig) {
 				s.bucketContainer.createNamespaceLocked(newNsCfg)
 			} else {
 				// Just correct the config pointer on the old namespace
-				ns.cfg = newNsCfg
+				ns.swapCfg(newNsCfg)
 			}
 		} else {
 			ns.destroy()


### PR DESCRIPTION
I was debugging some issue where a bucket exists in a config but
doesn't exist in Redis.

I'm not sure this change matters, but that was the only finding so far.

I'm not sure about the performance implication of this change..

r: @maniksurtani 
cc: @lukaszx0 @nicktrav @embark 