### PR TITLE
Reap old buckets more frequently

### DIFF
--- a/config/reaper.go
+++ b/config/reaper.go
@@ -17,5 +17,5 @@ func NewReaperConfig() ReaperConfig {
 	return ReaperConfig{
 		BucketWatcherBuffer: 10000,
 		InitSleep:           10 * time.Second,
-		MinFrequency:        1 * time.Hour}
+		MinFrequency:        10 * time.Minute}
 }


### PR DESCRIPTION
We see cases we reap too many old inactive buckets at the same time.

So, we should reap buckets more frequently. Setting
ReaperConfig.MinFrequency to 10 minutes would help.

@maniksurtani @embark @lukaszx0 @nicktrav 