### PR TITLE
buckets: Support a custom flushdb command

### DIFF
--- a/buckets/redis/bucket_test.go
+++ b/buckets/redis/bucket_test.go
@@ -40,7 +40,7 @@ func setUp() {
 	cfg = config.NewDefaultServiceConfig()
 	config.AddNamespace(cfg, dynNs)
 
-	factory = NewBucketFactory(&redis.Options{Addr: "localhost:6379"}, 2).(*bucketFactory)
+	factory = NewBucketFactory(&redis.Options{Addr: "localhost:6379"}, 2, "flushdb").(*bucketFactory)
 	factory.Init(cfg)
 	bucket = factory.NewBucket("redis", "redis", config.NewDefaultBucketConfig(""), false).(*staticBucket)
 }


### PR DESCRIPTION
Add another argument in bucketFactory to support a case where
the "flushdb" command is renamed to some other name for security reason.

r: @maniksurtani 
cc: @nicktrav @lukaszx0 @embark 