### PR TITLE
call applyWatch only for dynamic buckets

### DIFF
--- a/bucket.go
+++ b/bucket.go
@@ -275,12 +275,16 @@ func (bc *bucketContainer) createNewNamedBucketFromCfg(namespace, bucketName str
 		return nil
 	}
 
-	bucket, _ = bc.r.applyWatch(bucket, namespace, bucketName, bCfg)
-	ns.buckets[bucketName] = bucket
-
 	if dyn {
+		// Apply a watcher if a bucket is dynamic. We don't expire
+		// static buckets since FindBucket won't create a new bucket
+		// for static buckets. Also, removing idle static buckets
+		// won't help much since the number of static buckets is
+		// small.
+		bucket, _ = bc.r.applyWatch(bucket, namespace, bucketName, bCfg)
 		ns.dynamicBucketCount++
 	}
+	ns.buckets[bucketName] = bucket
 
 	bucket.ReportActivity()
 	return bucket


### PR DESCRIPTION
If we applyWatch to static buckets, Quota Service will delete old static buckets. However, bucketContainer.FindBucket will fail to find a bucket once it is deleted. (The function only creates new *dynamic* buckets.)

This commit fixes the bug by calling applyWatch only when a bucket is dynamic.