### PR TITLE
Make use of t.Helper() to make test failures clearer

### DIFF
--- a/admin/buckets_test.go
+++ b/admin/buckets_test.go
@@ -108,6 +108,8 @@ func TestBucketsDelete(t *testing.T) {
 }
 
 func doBucketsRequest(t *testing.T, a Administrable, object interface{}, method, path, body string) {
+	t.Helper()
+
 	apiHandler := newBucketsAPIHandler(a)
 	ts := httptest.NewServer(apiHandler)
 	defer ts.Close()

--- a/admin/configs_test.go
+++ b/admin/configs_test.go
@@ -46,6 +46,8 @@ func TestConfigsPut(t *testing.T) {
 }
 
 func doConfigsRequest(t *testing.T, a Administrable, object interface{}, method, path, body string) {
+	t.Helper()
+
 	apiHandler := newConfigsAPIHandler(a)
 	ts := httptest.NewServer(apiHandler)
 	defer ts.Close()

--- a/admin/namespaces_test.go
+++ b/admin/namespaces_test.go
@@ -99,6 +99,8 @@ func TestNamespacesDelete(t *testing.T) {
 }
 
 func doNamespacesRequest(t *testing.T, a Administrable, object interface{}, method, path, body string) {
+	t.Helper()
+
 	apiHandler := newNamespacesAPIHandler(a)
 	ts := httptest.NewServer(apiHandler)
 	defer ts.Close()

--- a/admin/stats_test.go
+++ b/admin/stats_test.go
@@ -96,6 +96,8 @@ func TestStatsGetBucket(t *testing.T) {
 }
 
 func doStatsRequest(t *testing.T, a Administrable, object interface{}, method, path, body string) {
+	t.Helper()
+
 	apiHandler := newStatsAPIHandler(a)
 	ts := httptest.NewServer(apiHandler)
 	defer ts.Close()

--- a/admin/ui_test.go
+++ b/admin/ui_test.go
@@ -55,6 +55,8 @@ func TestGetNotFound(t *testing.T) {
 }
 
 func getURL(url string, t *testing.T) string {
+	t.Helper()
+
 	res, err := http.Get(url)
 
 	if err != nil {

--- a/buckets/redis/bucket_test.go
+++ b/buckets/redis/bucket_test.go
@@ -120,6 +120,8 @@ func TestRefCountsForDynamic(t *testing.T) {
 }
 
 func assertNoSharedAttribs(t *testing.T) {
+	t.Helper()
+
 	if len(factory.sharedAttributes) != 0 {
 		t.Fatalf("Expected no shared attributes. Found %+v and refcounts %+v", factory.sharedAttributes, factory.refcounts)
 	}
@@ -130,6 +132,8 @@ func assertNoSharedAttribs(t *testing.T) {
 }
 
 func assertRefCounts(ns string, expected int, t *testing.T) {
+	t.Helper()
+
 	if _, exists := factory.sharedAttributes[ns]; !exists {
 		t.Fatalf("Expected shared attributes for namespace %v but found %+v", ns, factory.sharedAttributes)
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -69,6 +69,8 @@ func TestConfig(t *testing.T) {
 }
 
 func assertNamespace(t *testing.T, namespace string, ns *pbconfig.NamespaceConfig, numBuckets int, expectDefault, expectDynamic bool, maxDynamic int32) {
+	t.Helper()
+
 	if namespace != ns.Name {
 		t.Fatalf("namespace.Name is %v and not %v", ns.Name, namespace)
 	}
@@ -91,6 +93,8 @@ func assertNamespace(t *testing.T, namespace string, ns *pbconfig.NamespaceConfi
 }
 
 func assertBucket(t *testing.T, name, namespace string, b *pbconfig.BucketConfig, size, fillRate, waitTimeoutMillis, maxIdleMillis, maxDebtMillis, maxTokensPerRequest int64) {
+	t.Helper()
+
 	if b == nil {
 		t.Fatal("Bucket doesn't exist")
 	}

--- a/events_test.go
+++ b/events_test.go
@@ -155,6 +155,8 @@ func TestBucketRemoval(t *testing.T) {
 }
 
 func checkEvent(namespace, name string, dyn bool, eventType events.EventType, tokens int64, waitTime time.Duration, actual events.Event, t *testing.T) {
+	t.Helper()
+
 	if actual == nil {
 		t.Fatal("Expecting event; was nil.")
 	}

--- a/server_test.go
+++ b/server_test.go
@@ -107,6 +107,8 @@ func TestTooManyTokensRequested(t *testing.T) {
 }
 
 func stopServer(t *testing.T, s *server) {
+	t.Helper()
+
 	_, err := s.Stop()
 	helpers.CheckError(t, err)
 }

--- a/test/helpers/helpers.go
+++ b/test/helpers/helpers.go
@@ -9,6 +9,8 @@ import (
 // ExpectingPanic indicates that a function passed in should panic. If it does, no errors are
 // thrown. If not, the test fails.
 func ExpectingPanic(t *testing.T, f func()) {
+	t.Helper()
+
 	defer func() {
 		if r := recover(); r == nil {
 			t.Fatalf("Did not panic()")
@@ -22,6 +24,8 @@ func ExpectingPanic(t *testing.T, f func()) {
 
 // CheckError tests if the error is not nil, and fails the test if so.
 func CheckError(t *testing.T, e error) {
+	t.Helper()
+
 	if e != nil {
 		_, file, line, _ := runtime.Caller(1)
 		t.Fatalf("Not expecting error %+v from (%s:%d)", e, file, line)


### PR DESCRIPTION
`t.Helper()` added in Go 1.9