### PR TITLE
Updating the apiVersionHandler.

### DIFF
--- a/admin/admin.go
+++ b/admin/admin.go
@@ -116,11 +116,9 @@ func apiVersionHandler(a Administrable, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		versionHeader := r.Header.Get("Version")
 
-		if r.Method == http.MethodGet {
-			if versionHeader == "" {
-				next.ServeHTTP(w, r)
-				return
-			}
+		if r.Method == http.MethodGet && versionHeader == "" {
+			next.ServeHTTP(w, r)
+			return
 		}
 
 		version, err := strconv.Atoi(versionHeader)

--- a/admin/admin.go
+++ b/admin/admin.go
@@ -116,14 +116,16 @@ func apiVersionHandler(a Administrable, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		versionHeader := r.Header.Get("Version")
 
-		if versionHeader == "" {
-			next.ServeHTTP(w, r)
-			return
+		if r.Method == http.MethodGet {
+			if versionHeader == "" {
+				next.ServeHTTP(w, r)
+				return
+			}
 		}
 
 		version, err := strconv.Atoi(versionHeader)
 		if err != nil {
-			writeJSONError(w, &httpError{err.Error(), http.StatusInternalServerError})
+			writeJSONError(w, &httpError{fmt.Sprintf("There was an error parsing the 'Version' header. Please verify version is provided and is properly formatted. %s", err.Error()), http.StatusBadRequest})
 			return
 		}
 


### PR DESCRIPTION
Currently, POST requests without a 'Version' header are version controlled. This allows two users to modify configurations concurrently in a race condition without optimistic locking.

The change made to the apiVersionHandler function does not allow POST requests without Version header.