### PR TITLE
Go tests weren't being run by travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,5 @@
 language: go
 
-go:
-  - 1.9
-
 cache:
   directories:
     - admin/public/node_modules
@@ -12,6 +9,10 @@ services:
 
 matrix:
   include:
+    # Default: go test ./...
+    - go: 1.9
+
+    # Runs tests for admin UI
     - go: 1.x
       env: TEST=UI
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ matrix:
       env: TEST=UI
 
 install:
-  - wget http://apache.claz.org/zookeeper/stable/zookeeper-3.4.10.tar.gz
+  - wget https://archive.apache.org/dist/zookeeper/zookeeper-3.4.9/zookeeper-3.4.9.tar.gz
   - tar -zxf zookeeper*tar.gz
   - 'if [ "$TEST" == "UI" ]; then nvm install 6; fi'
 

--- a/admin/admin_test.go
+++ b/admin/admin_test.go
@@ -22,7 +22,7 @@ func TestNamespacesPostWithVersion(t *testing.T) {
 	jsonResponse := executeRequestForVersioningTest(ts, true, http.MethodPost, "3", t)
 
 	if jsonResponse["error"] != "" {
-		t.Errorf("POST request with correct version header should succeed", jsonResponse)
+		t.Errorf("POST request with correct version header should succeed: %+v", jsonResponse)
 	}
 }
 
@@ -62,7 +62,7 @@ func TestNamespacesGetWithVersion(t *testing.T) {
 	jsonResponse := executeRequestForVersioningTest(ts, true, http.MethodGet, "3", t)
 
 	if jsonResponse["error"] != "" {
-		t.Errorf("GET request with correct version header should succeed", jsonResponse)
+		t.Errorf("GET request with correct version header should succeed: %+v", jsonResponse)
 	}
 }
 
@@ -72,7 +72,7 @@ func TestNamespacesGetNoVersion(t *testing.T) {
 	jsonResponse := executeRequestForVersioningTest(ts, false, http.MethodGet, "", t)
 
 	if jsonResponse["error"] != "" {
-		t.Errorf("GET request without version header should succeed", jsonResponse)
+		t.Errorf("GET request without version header should succeed: %+v", jsonResponse)
 	}
 }
 


### PR DESCRIPTION
* Fix a `go vet` error
* Fix for zookeeper not being able to run >= 3.4.10