### PR TITLE
Guard against lower valued config version updates

### DIFF
--- a/buckets/redis/bucket_factory.go
+++ b/buckets/redis/bucket_factory.go
@@ -82,6 +82,12 @@ func (bf *bucketFactory) Init(cfg *pbconfig.ServiceConfig) {
 	bf.Lock()
 	defer bf.Unlock()
 
+	// Guard against updating the existing config with a lower valued version number
+	if bf.cfg != nil && cfg.Version <= bf.cfg.Version {
+		logging.Printf("Proposed config version %d is lower than existing config version %d. Ignoring.",
+			cfg.Version, bf.cfg.Version)
+		return
+	}
 	bf.cfg = cfg
 
 	if bf.client == nil {

--- a/buckets/redis/bucket_test.go
+++ b/buckets/redis/bucket_test.go
@@ -133,6 +133,26 @@ func TestRefCountsForDynamic(t *testing.T) {
 	assertNoSharedAttribs(t)
 }
 
+func TestInitWithLowerVersionedConfig(t *testing.T) {
+	// Write a config with version 2
+	cfg = config.NewDefaultServiceConfig()
+	cfg.Version = 2
+	factory.Init(cfg)
+
+	if factory.cfg.Version != 2 {
+		t.Fatal("Expected version 2")
+	}
+
+	// Attempt to write a version 1 of the config
+	newCfg := config.NewDefaultServiceConfig()
+	newCfg.Version = 1
+	factory.Init(newCfg)
+
+	if factory.cfg.Version != 2 {
+		t.Fatal("Expected version 2 to not have been overwritten")
+	}
+}
+
 func assertNoSharedAttribs(t *testing.T) {
 	t.Helper()
 


### PR DESCRIPTION
Currently if bucketFactory.Init receives a config with a version number
that is lower than the existing config, the existing configuration will
be overwritten.

Guard against updates from configs with lower version numbers than the
existing config by ensuring that an update can only proceed if the
config version is strictly greater than the existing config version.