### PR TITLE
Change Persister API to use *quotaservice_config.ServiceConfig rather…

### DIFF
--- a/config/disk_persister_test.go
+++ b/config/disk_persister_test.go
@@ -35,9 +35,7 @@ func TestDiskPersistence(t *testing.T) {
 	helpers.CheckError(t, AddNamespace(s, nc))
 
 	// Store s.
-	r, e := Marshal(s)
-	helpers.CheckError(t, e)
-	e = persister.PersistAndNotify(r)
+	e = persister.PersistAndNotify("", s)
 	helpers.CheckError(t, e)
 
 	// Test notification
@@ -48,9 +46,7 @@ func TestDiskPersistence(t *testing.T) {
 		t.Fatal("Config channel should not be empty!")
 	}
 
-	r, e = persister.ReadPersistedConfig()
-	helpers.CheckError(t, e)
-	unmarshalled, e := Unmarshal(r)
+	unmarshalled, e := persister.ReadPersistedConfig()
 	helpers.CheckError(t, e)
 
 	if !reflect.DeepEqual(s, unmarshalled) {
@@ -64,8 +60,7 @@ func TestDiskPersistence(t *testing.T) {
 		t.Fatalf("Historical configs is not correct! %+v", cfgs)
 	}
 
-	unmarshalled, e = Unmarshal(cfgs[0])
-	helpers.CheckError(t, e)
+	unmarshalled = cfgs[0]
 
 	if !reflect.DeepEqual(s, unmarshalled) {
 		t.Fatalf("Configs should be equal! %+v != %+v", s, unmarshalled)

--- a/config/memory_persister_test.go
+++ b/config/memory_persister_test.go
@@ -34,9 +34,7 @@ func TestMemoryPersistence(t *testing.T) {
 	helpers.CheckError(t, AddNamespace(s, nc))
 
 	// Store s.
-	r, e := Marshal(s)
-	helpers.CheckError(t, e)
-	e = persister.PersistAndNotify(r)
+	e := persister.PersistAndNotify("", s)
 	helpers.CheckError(t, e)
 
 	// Test notification
@@ -47,9 +45,7 @@ func TestMemoryPersistence(t *testing.T) {
 		t.Fatal("Config channel should not be empty!")
 	}
 
-	r, e = persister.ReadPersistedConfig()
-	helpers.CheckError(t, e)
-	unmarshalled, e := Unmarshal(r)
+	unmarshalled, e := persister.ReadPersistedConfig()
 	helpers.CheckError(t, e)
 
 	if !reflect.DeepEqual(s, unmarshalled) {
@@ -63,10 +59,7 @@ func TestMemoryPersistence(t *testing.T) {
 		t.Fatalf("Historical configs is not correct! %+v", cfgs)
 	}
 
-	unmarshalled, e = Unmarshal(cfgs[0])
-	helpers.CheckError(t, e)
-
-	if !reflect.DeepEqual(s, unmarshalled) {
-		t.Fatalf("Configs should be equal! %+v != %+v", s, unmarshalled)
+	if !reflect.DeepEqual(s, cfgs[0]) {
+		t.Fatalf("Configs should be equal! %+v != %+v", s, cfgs[0])
 	}
 }

--- a/server_test.go
+++ b/server_test.go
@@ -18,7 +18,7 @@ func TestWithNoRpcs(t *testing.T) {
 }
 
 func TestValidServer(t *testing.T) {
-	s := New(&MockBucketFactory{}, config.NewMemoryConfigPersister(), NewReaperConfigForTests(), 0, &MockEndpoint{}).(*server)
+	s := New(&MockBucketFactory{}, config.NewMemoryConfig(config.NewDefaultServiceConfig()), NewReaperConfigForTests(), 0, &MockEndpoint{}).(*server)
 	_, err := s.Start()
 	helpers.CheckError(t, err)
 	stopServer(t, s)
@@ -31,15 +31,9 @@ func TestUpdateConfig(t *testing.T) {
 	originalConfig := config.NewDefaultServiceConfig()
 	originalConfig.Version = 2
 	originalConfig.Date = time.Now().Unix() - 10
-	marshalledConfig, err := config.Marshal(originalConfig)
+	helpers.CheckError(t, p.PersistAndNotify("", originalConfig))
 
-	if err != nil {
-		t.Fatal("Error when updating config", err)
-	}
-
-	helpers.CheckError(t, p.PersistAndNotify(marshalledConfig))
-
-	_, err = s.Start()
+	_, err := s.Start()
 	helpers.CheckError(t, err)
 	defer stopServer(t, s)
 


### PR DESCRIPTION
… than io.Reader, add 'oldHash' to the PersistAndNotify API

* Still no code actually makes use of 'oldHash' - that's a separate PR

Sorry about the massive refactoring PR - this is what happens when changing method signatures on such a central interface though! :/