### PR TITLE
Replace Redis flush with versioned keys

### DIFF
--- a/buckets/redis/bucket.go
+++ b/buckets/redis/bucket.go
@@ -46,9 +46,14 @@ func (a *abstractBucket) Config() *pbconfig.BucketConfig {
 func (a *abstractBucket) Take(requested int64, maxWaitTime time.Duration) (time.Duration, bool) {
 	currentTimeNanos := strconv.FormatInt(time.Now().UnixNano(), 10)
 
+	maxIdleTimeMillis := a.maxIdleTimeMillis
+	if a.maxIdleTimeMillis == "0" {
+		// bucket MaxIdleMillis was not set; fall back to factory setting
+		maxIdleTimeMillis = strconv.FormatInt(int64(a.factory.keyMaxIdleTime/time.Millisecond), 10)
+	}
 	args := []interface{}{currentTimeNanos, a.nanosBetweenTokens, a.maxTokensToAccumulate,
 		strconv.FormatInt(requested, 10), strconv.FormatInt(maxWaitTime.Nanoseconds(), 10),
-		a.maxIdleTimeMillis, a.maxDebtNanos}
+		maxIdleTimeMillis, a.maxDebtNanos}
 
 	var waitTime time.Duration
 	var err error

--- a/buckets/redis/bucket_test.go
+++ b/buckets/redis/bucket_test.go
@@ -41,7 +41,7 @@ func setUp() {
 	cfg = config.NewDefaultServiceConfig()
 	config.AddNamespace(cfg, dynNs)
 
-	factory = NewBucketFactory(&redis.Options{Addr: "localhost:6379"}, 2, "flushdb").(*bucketFactory)
+	factory = NewBucketFactory(&redis.Options{Addr: "localhost:6379"}, 2, 0).(*bucketFactory)
 	factory.Init(cfg)
 	bucket = factory.NewBucket("redis", "redis", config.NewDefaultBucketConfig(""), false).(*staticBucket)
 }


### PR DESCRIPTION
The linear-time flush could block Redis's single thread for seconds in
Quotaservice deployments with hundreds of thousands of buckets (or more)
whenever config updates were made. This commit removes flush entirely,
instead scoping a bucket's keys to the current config version. The
existing maxIdleTimeMillis bucket attribute can be used to prune
outdated keys. If the max idle time is not configured for a given
bucket, the bucket factory max idle time will be used as the Redis key
TTL to ensure old keys are eventually removed.