### PR TITLE
Fail open if the server encounters an error

### DIFF
--- a/bucket.go
+++ b/bucket.go
@@ -50,7 +50,7 @@ type Bucket interface {
 	// the number of tokens becomes available. A return value of 0 would mean no waiting is
 	// necessary. Success is true if tokens can be obtained, false if cannot be obtained within
 	// the specified maximum wait time.
-	Take(ctx context.Context, numTokens int64, maxWaitTime time.Duration) (waitTime time.Duration, success bool)
+	Take(ctx context.Context, numTokens int64, maxWaitTime time.Duration) (waitTime time.Duration, success bool, err error)
 	Config() *pbconfig.BucketConfig
 	// Dynamic indicates whether a bucket is a dynamic one, or one that is statically defined in
 	// configuration.

--- a/buckets/bucket_impl_tests.go
+++ b/buckets/bucket_impl_tests.go
@@ -17,7 +17,10 @@ func TestTokenAcquisition(t *testing.T, bucket quotaservice.Bucket) {
 	// Clear any stale state
 	bucket.Take(context.Background(), 1, 0)
 
-	wait, s := bucket.Take(context.Background(), 1, 0)
+	wait, s, err := bucket.Take(context.Background(), 1, 0)
+	if err != nil {
+		t.Fatalf("expected a nil error, got %s", err)
+	}
 	if wait != 0 {
 		t.Fatalf("Expecting 0 wait. Was %v", wait)
 	}
@@ -26,8 +29,10 @@ func TestTokenAcquisition(t *testing.T, bucket quotaservice.Bucket) {
 	}
 
 	// Consume all tokens. This should work too.
-	wait, s = bucket.Take(context.Background(), 100, 0)
-
+	wait, s, err = bucket.Take(context.Background(), 100, 0)
+	if err != nil {
+		t.Fatalf("expected a nil error, got %s", err)
+	}
 	if wait != 0 {
 		t.Fatalf("Expecting 0 wait. Was %v", wait)
 	}
@@ -36,7 +41,10 @@ func TestTokenAcquisition(t *testing.T, bucket quotaservice.Bucket) {
 	}
 
 	// Should have no more left. Should have to wait.
-	wait, s = bucket.Take(context.Background(), 10, 10*time.Second)
+	wait, s, err = bucket.Take(context.Background(), 10, 10*time.Second)
+	if err != nil {
+		t.Fatalf("expected a nil error, got %s", err)
+	}
 	if wait < 1 {
 		t.Fatalf("Expecting positive wait time. Was %v", wait)
 	}
@@ -45,7 +53,10 @@ func TestTokenAcquisition(t *testing.T, bucket quotaservice.Bucket) {
 	}
 
 	// If we don't want to wait...
-	wait, s = bucket.Take(context.Background(), 10, 0)
+	wait, s, err = bucket.Take(context.Background(), 10, 0)
+	if err != nil {
+		t.Fatalf("expected a nil error, got %s", err)
+	}
 	if wait != 0 {
 		t.Fatalf("Expecting 0 wait time. Was %v", wait)
 	}

--- a/buckets/redis/bucket_factory_test.go
+++ b/buckets/redis/bucket_factory_test.go
@@ -1,0 +1,45 @@
+package redis
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/pkg/errors"
+)
+
+func TestIsRedisClientClosedError(t *testing.T) {
+	tests := []struct {
+		input        error
+		isCloseError bool
+	}{
+		{
+			// Test exactly the error
+			input:        fmt.Errorf(redisClientClosedError),
+			isCloseError: true,
+		},
+		{
+			// Test the error wrapped
+			input:        errors.Wrap(fmt.Errorf(redisClientClosedError), "obfuscate"),
+			isCloseError: true,
+		},
+		{
+			// test not the error
+			input:        errors.New("just another error"),
+			isCloseError: false,
+		},
+		{
+			// test not the error wrapped with the text of the error (this should never happen)
+			input:        errors.Wrap(errors.New("just another error"), redisClientClosedError),
+			isCloseError: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.input.Error(), func(t *testing.T) {
+			result := isRedisClientClosedError(test.input)
+			if result != test.isCloseError {
+				t.Fatal("failed to detect error")
+			}
+		})
+	}
+}

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/square/quotaservice"
 	"github.com/square/quotaservice/buckets/memory"
 	"github.com/square/quotaservice/config"
+	"github.com/square/quotaservice/events"
 	pb "github.com/square/quotaservice/protos"
 	qsgrpc "github.com/square/quotaservice/rpc/grpc"
 	"github.com/square/quotaservice/test/helpers"
@@ -42,7 +43,7 @@ func setUp() {
 		config.NewMemoryConfig(cfg),
 		quotaservice.NewReaperConfigForTests(),
 		0,
-		qsgrpc.New(target))
+		qsgrpc.New(target, events.NewNilProducer()))
 
 	if _, err := server.Start(); err != nil {
 		helpers.PanicError(err)

--- a/events/events.go
+++ b/events/events.go
@@ -4,9 +4,8 @@
 package events
 
 import (
-	"time"
-
 	"fmt"
+	"time"
 
 	"github.com/square/quotaservice/logging"
 )
@@ -20,6 +19,7 @@ const (
 	EVENT_BUCKET_MISS
 	EVENT_BUCKET_CREATED
 	EVENT_BUCKET_REMOVED
+	EVENT_SERVER_ERROR
 )
 
 var eventNames = []string{
@@ -28,7 +28,9 @@ var eventNames = []string{
 	EVENT_TOO_MANY_TOKENS_REQUESTED: "EVENT_TOO_MANY_TOKENS_REQUESTED",
 	EVENT_BUCKET_MISS:               "EVENT_BUCKET_MISS",
 	EVENT_BUCKET_CREATED:            "EVENT_BUCKET_CREATED",
-	EVENT_BUCKET_REMOVED:            "EVENT_BUCKET_REMOVED"}
+	EVENT_BUCKET_REMOVED:            "EVENT_BUCKET_REMOVED",
+	EVENT_SERVER_ERROR:              "EVENT_SERVER_ERROR",
+}
 
 func (et EventType) String() string {
 	name := eventNames[et]
@@ -187,10 +189,19 @@ func NewBucketRemovedEvent(namespace, bucketName string, dynamic bool) Event {
 	return newNamedEvent(namespace, bucketName, dynamic, EVENT_BUCKET_REMOVED)
 }
 
+// NewBucketRemovedEvent creates a new event with the type EVENT_BUCKET_REMOVED
+func NewServerErrorEvent(namespace, bucketName string, dynamic bool) Event {
+	return newNamedEvent(namespace, bucketName, dynamic, EVENT_SERVER_ERROR)
+}
+
 func newNamedEvent(namespace, bucketName string, dynamic bool, eventType EventType) *namedEvent {
 	return &namedEvent{
 		eventType:  eventType,
 		namespace:  namespace,
 		bucketName: bucketName,
 		dynamic:    dynamic}
+}
+
+func NewNilProducer() *EventProducer {
+	return RegisterListener(func(_ Event) {}, 0)
 }

--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/opencontainers/runc v0.1.1 // indirect
 	github.com/opentracing/opentracing-go v1.0.2
 	github.com/ory/dockertest v3.3.4+incompatible
-	github.com/pkg/errors v0.8.1 // indirect
+	github.com/pkg/errors v0.8.1
 	github.com/samuel/go-zookeeper v0.0.0-20161028232340-1d7be4effb13
 	github.com/sergi/go-diff v1.0.0 // indirect
 	github.com/sirupsen/logrus v1.3.0 // indirect

--- a/stats/redis_test.go
+++ b/stats/redis_test.go
@@ -34,7 +34,7 @@ func randomNamespace() string {
 
 const (
 	batchSubmitInterval = 2 * time.Millisecond
-	waitForBatchSubmit = 10 * batchSubmitInterval
+	waitForBatchSubmit  = 10 * batchSubmitInterval
 )
 
 func setUp() Listener {
@@ -199,9 +199,9 @@ func TestRedisTop10Misses(t *testing.T) {
 	teardown(listener)
 }
 
-func TestRedisBatching( t *testing.T) {
+func TestRedisBatching(t *testing.T) {
 	setUp()
-	listener := NewRedisStatsListener(&redis.Options{Addr: "localhost:6379"}, 128, 5 * time.Second)
+	listener := NewRedisStatsListener(&redis.Options{Addr: "localhost:6379"}, 128, 5*time.Second)
 
 	for i := 0; i < 127; i++ {
 		listener.HandleEvent(events.NewBucketMissedEvent(namespace, "misses-dyn-1", true))

--- a/test/main.go
+++ b/test/main.go
@@ -13,6 +13,7 @@ import (
 	"github.com/square/quotaservice"
 	"github.com/square/quotaservice/buckets/memory"
 	"github.com/square/quotaservice/config"
+	"github.com/square/quotaservice/events"
 	"github.com/square/quotaservice/logging"
 	"github.com/square/quotaservice/rpc/grpc"
 	"github.com/square/quotaservice/stats"
@@ -44,7 +45,7 @@ func main() {
 		config.NewMemoryConfig(cfg),
 		config.NewReaperConfig(),
 		0,
-		grpc.New(gRPCServer))
+		grpc.New(gRPCServer, events.NewNilProducer()))
 	server.SetStatsListener(stats.NewMemoryStatsListener())
 	if _, e := server.Start(); e != nil {
 		panic(e)

--- a/test_mocks.go
+++ b/test_mocks.go
@@ -15,6 +15,8 @@ import (
 	pbconfig "github.com/square/quotaservice/protos/config"
 )
 
+var _ Bucket = (*MockBucket)(nil)
+
 type MockBucket struct {
 	sync.RWMutex
 	DefaultBucket
@@ -24,15 +26,15 @@ type MockBucket struct {
 	cfg                   *pbconfig.BucketConfig
 }
 
-func (b *MockBucket) Take(_ context.Context, numTokens int64, maxWaitTime time.Duration) (time.Duration, bool) {
+func (b *MockBucket) Take(_ context.Context, numTokens int64, maxWaitTime time.Duration) (time.Duration, bool, error) {
 	b.RLock()
 	defer b.RUnlock()
 
 	if b.WaitTime > maxWaitTime {
-		return 0, false
+		return 0, false, nil
 	}
 
-	return b.WaitTime, true
+	return b.WaitTime, true, nil
 }
 func (b *MockBucket) Config() *pbconfig.BucketConfig {
 	return b.cfg


### PR DESCRIPTION
This solves a few problems:

- QS would fail closed if the redis connection failed.
- We deny `Allow` requests if QS encounters an error, which is _very_ not fail open. Clients can ignore it, but that shouldn't be necessary