### PR TITLE
Emit an event when a Take() error occurs on a bucket

### DIFF
--- a/events/events.go
+++ b/events/events.go
@@ -20,6 +20,7 @@ const (
 	EVENT_BUCKET_CREATED
 	EVENT_BUCKET_REMOVED
 	EVENT_SERVER_ERROR
+	EVENT_BUCKET_ERROR
 )
 
 var eventNames = []string{
@@ -30,6 +31,7 @@ var eventNames = []string{
 	EVENT_BUCKET_CREATED:            "EVENT_BUCKET_CREATED",
 	EVENT_BUCKET_REMOVED:            "EVENT_BUCKET_REMOVED",
 	EVENT_SERVER_ERROR:              "EVENT_SERVER_ERROR",
+	EVENT_BUCKET_ERROR:              "EVENT_BUCKET_ERROR",
 }
 
 func (et EventType) String() string {
@@ -189,9 +191,16 @@ func NewBucketRemovedEvent(namespace, bucketName string, dynamic bool) Event {
 	return newNamedEvent(namespace, bucketName, dynamic, EVENT_BUCKET_REMOVED)
 }
 
-// NewBucketRemovedEvent creates a new event with the type EVENT_BUCKET_REMOVED
+// NewServerErrorEvent creates a new event with the type EVENT_SERVER_ERROR
 func NewServerErrorEvent(namespace, bucketName string, dynamic bool) Event {
 	return newNamedEvent(namespace, bucketName, dynamic, EVENT_SERVER_ERROR)
+}
+
+// NewBucketErrorEvent creates a new event with type EVENT_BUCKET_ERROR. It
+// indicates an error attempting to take tokens from a bucket, e.g. a redis
+// operation failure.
+func NewBucketErrorEvent(namespace, bucketName string, dynamic bool) Event {
+	return newNamedEvent(namespace, bucketName, dynamic, EVENT_BUCKET_ERROR)
 }
 
 func newNamedEvent(namespace, bucketName string, dynamic bool, eventType EventType) *namedEvent {

--- a/server.go
+++ b/server.go
@@ -136,6 +136,7 @@ func (s *server) Allow(ctx context.Context, namespace, name string, tokensReques
 
 	w, success, err := b.Take(ctx, tokensRequested, maxWaitTime)
 	if err != nil {
+		s.Emit(events.NewBucketErrorEvent(namespace, name, b.Dynamic()))
 		return 0, b.Dynamic(), errors.Wrap(err, "failed to take tokens")
 	}
 


### PR DESCRIPTION
We emit events for other event types, such as bucket misses or when too
many tokens are requested, however listeners did not previously have a
way to tell if an error occurred due to a Take() operation failure