### PR TITLE
Evaluate "current time" based on redis client instead of quotaservice to avoid setting TNA to the future

### DIFF
--- a/buckets/redis/bucket.go
+++ b/buckets/redis/bucket.go
@@ -42,14 +42,12 @@ func (a *abstractBucket) Config() *pbconfig.BucketConfig {
 }
 
 func (a *abstractBucket) Take(ctx context.Context, requested int64, maxWaitTime time.Duration) (time.Duration, bool, error) {
-	currentTimeNanos := strconv.FormatInt(time.Now().UnixNano(), 10)
-
 	maxIdleTimeMillis := a.maxIdleTimeMillis
 	if a.maxIdleTimeMillis == "0" {
 		// bucket MaxIdleMillis was not set; fall back to factory setting
 		maxIdleTimeMillis = strconv.FormatInt(int64(a.factory.keyMaxIdleTime/time.Millisecond), 10)
 	}
-	args := []interface{}{currentTimeNanos, a.nanosBetweenTokens, a.maxTokensToAccumulate,
+	args := []interface{}{a.nanosBetweenTokens, a.maxTokensToAccumulate,
 		strconv.FormatInt(requested, 10), strconv.FormatInt(maxWaitTime.Nanoseconds(), 10),
 		maxIdleTimeMillis, a.maxDebtNanos}
 


### PR DESCRIPTION
The issue happens if a quotaservice has a clock that's in the future,
thus sets TNA (token next available) to the future. Then on
the next request from a normal time quotaservice, the current
time < TNA so the wait time becomes positive.

```
if currentTimeNanos > tokensNextAvailableNanos then
	freshTokens = math.floor((currentTimeNanos - tokensNextAvailableNanos) / nanosBetweenTokens)
	accumulatedTokens = math.min(maxTokensToAccumulate, accumulatedTokens + freshTokens)
	tokensNextAvailableNanos = currentTimeNanos
end

local waitTime = tokensNextAvailableNanos - currentTimeNanos
```