### PR TITLE
Fix cli to use beyond-curl

### DIFF
--- a/admin/public/src/components/Error.jsx
+++ b/admin/public/src/components/Error.jsx
@@ -6,16 +6,16 @@ export default class Error extends Component {
   renderError(error) {
     switch (error.name) {
       case 'RequestError':
-        return `A network error occurred: "${error.message}"`
+        return `A network error occurred: "${error.message}"`;
       case 'ApiError':
         if (error.response) {
-          return error.response.description
-        } else {
-          return `An error occurred: "${error.statusText}"`
+          return error.response.description;
         }
+        return `An error occurred: "${error.statusText}"`;
       case 'InternalError':
       default:
-        return 'An unknown error occurred. Please contact your friendly QuotaService owners for help.'
+        console.log(error.message);
+        return 'An unknown error occurred. Please contact your friendly QuotaService owners for help.';
     }
   }
 

--- a/quotaservice-cli/client/client.go
+++ b/quotaservice-cli/client/client.go
@@ -10,8 +10,8 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"net/http"
 	"os"
+	"os/exec"
 
 	"github.com/square/quotaservice/config"
 	"gopkg.in/alecthomas/kingpin.v2"
@@ -20,8 +20,7 @@ import (
 var (
 	app     = kingpin.New("quotaservice-cli", "The quotaservice CLI tool.")
 	verbose = app.Flag("verbose", "Verbose output").Short('v').Default("false").Bool()
-	host    = app.Flag("host", "Host address").Short('h').Default("localhost").String()
-	port    = app.Flag("port", "Host port").Short('p').Default("80").Int()
+	env     = app.Flag("env", "Environment").Short('e').Enum("production", "staging", "local")
 
 	// show
 	show          = app.Command("show", "Show configuration for the entire service, optionally filtered by namespace and/or bucket name.")
@@ -76,17 +75,14 @@ func doShow(gdb bool, namespace, bucket string) {
 	logf("Called show(gdb=%v, namespace=%v, bucket=%v)\n", gdb, namespace, bucket)
 	url := createUrl(gdb, namespace, bucket)
 	resp := connectToServer("GET", url)
-	defer func() { _ = resp.Body.Close() }()
-	body, e := ioutil.ReadAll(resp.Body)
-	kingpin.FatalIfError(e, "Error reading HTTP response")
 
 	if *output == "" {
-		fmt.Print(string(body))
+		fmt.Print(resp)
 	} else {
 		logf("Writing to %v\n", *output)
 		f, err := os.Create(*output)
 		kingpin.FatalIfError(err, "Cannot write to file %v", *output)
-		_, err = f.WriteString(string(body))
+		_, err = f.WriteString(resp)
 		kingpin.FatalIfError(err, "Cannot write to file %v", *output)
 		err = f.Close()
 		kingpin.FatalIfError(err, "Cannot write to file %v", *output)
@@ -98,16 +94,14 @@ func doAdd(gdb bool, namespace, bucket string) {
 	logf("Called add(gdb=%v, namespace=%v, bucket=%v)\n", gdb, namespace, bucket)
 	cfgBytes := readCfg(*addFile, namespace, bucket)
 	url := createUrl(gdb, namespace, bucket)
-	resp := connectToServer("POST", url, cfgBytes)
-	_ = resp.Body.Close()
+	connectToServer("POST", url, cfgBytes)
 }
 
 func doRemove(gdb bool, namespace, bucket string) {
 	validate(gdb, namespace, bucket)
 	logf("Called remove(gdb=%v, namespace=%v, bucket=%v)\n", gdb, namespace, bucket)
 	url := createUrl(gdb, namespace, bucket)
-	resp := connectToServer("DELETE", url)
-	_ = resp.Body.Close()
+	connectToServer("DELETE", url)
 }
 
 func doUpdate(gdb bool, namespace, bucket string) {
@@ -115,8 +109,7 @@ func doUpdate(gdb bool, namespace, bucket string) {
 	logf("Called update(gdb=%v, namespace=%v, bucket=%v)\n", gdb, namespace, bucket)
 	cfgBytes := readCfg(*updateFile, namespace, bucket)
 	url := createUrl(gdb, namespace, bucket)
-	resp := connectToServer("PUT", url, cfgBytes)
-	_ = resp.Body.Close()
+	connectToServer("PUT", url, cfgBytes)
 }
 
 func readCfg(f, namespace, bucket string) []byte {
@@ -187,7 +180,7 @@ func validate(gdb bool, namespace, bucket string) {
 	}
 }
 
-func connectToServer(method, url string, data ...[]byte) *http.Response {
+func connectToServer(method, url string, data ...[]byte) string {
 	var dataReader io.Reader
 
 	switch len(data) {
@@ -199,22 +192,21 @@ func connectToServer(method, url string, data ...[]byte) *http.Response {
 		panic("Should never get here")
 	}
 
-	r, e := http.NewRequest(method, url, dataReader)
-	kingpin.FatalIfError(e, "HTTP error")
-
-	client := &http.Client{}
-	resp, e := client.Do(r)
-	kingpin.FatalIfError(e, "HTTP error")
-
-	logf("Response Status: %v\n", resp.Status)
-	logf("Response Headers: %v\n", resp.Header)
-	if resp.StatusCode != 200 {
-		defer func() { _ = resp.Body.Close() }()
-		body, _ := ioutil.ReadAll(resp.Body)
-		kingpin.Fatalf("HTTP request failed with status %v and reason %v\n", resp.StatusCode, string(body))
+	cmdTokens := []string{"-sS", "-X", method, url, "-H", "Content-Type: application/json"}
+	if dataReader != nil {
+		cmdTokens = append(cmdTokens, "--data", string(data[0]))
 	}
 
-	return resp
+	cmd := exec.Command("beyond-curl", cmdTokens...)
+
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	if err != nil {
+		kingpin.Fatalf("beyond-curl command failed with error: %v", err)
+	}
+	return out.String()
 }
 
 func createUrl(gdb bool, namespace, bucket string) string {
@@ -229,7 +221,14 @@ func createUrl(gdb bool, namespace, bucket string) string {
 		}
 	}
 
-	url := fmt.Sprintf("http://%v:%v/api/%v", *host, *port, uri)
+	host := "localhost:3000"
+	if *env == "staging" {
+		host = "quotaservice.stage.sqprod.co"
+	} else if *env == "production" {
+		host = "quotaservice.sqprod.co"
+	}
+
+	url := fmt.Sprintf("https://%v/api/%v", host, uri)
 	logf("Connecting to URL %v\n", url)
 	return url
 }


### PR DESCRIPTION
The `quotaservice-cli` is broken. Fix it by make it call `beyond-curl https://quotaservice.[stage.]sqprod.co`. Tested with local build.

Also sneak in a little change to print the error to browser console when fail the loading.