### PR TITLE
Return Version in response header

### DIFF
--- a/admin/admin.go
+++ b/admin/admin.go
@@ -116,7 +116,8 @@ func apiVersionHandler(a Administrable, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		versionHeader := r.Header.Get("Version")
 
-		if r.Method == http.MethodGet && versionHeader == "" {
+		if r.Method == http.MethodGet {
+			w.Header().Set("Version", fmt.Sprintf("%v", a.Configs().Version))
 			next.ServeHTTP(w, r)
 			return
 		}

--- a/admin/buckets.go
+++ b/admin/buckets.go
@@ -82,7 +82,8 @@ func getBucketConfig(r io.Reader) (*pb.BucketConfig, error) {
 }
 
 func writeBucket(a *bucketsAPIHandler, w http.ResponseWriter, namespace, bucket string) *httpError {
-	namespaceConfig, exists := a.a.Configs().Namespaces[namespace]
+	config := a.a.Configs()
+	namespaceConfig, exists := config.Namespaces[namespace]
 
 	if !exists {
 		return &httpError{"Unable to locate namespace " + namespace, http.StatusNotFound}


### PR DESCRIPTION
## What
This allows the `quotaservice-cli` to add/update/delete namespace/bucket config.

The write operations (add/update/delete) needs a `Version` header in the request, and require the version to match the current config version, to achieve optimistic update. Without this header, the write operation will fail ([here](https://github.com/square/quotaservice/blob/44c0db092cd1dcf7999d5df1d5c0e11a4cd2b0ec/admin/admin.go#L119-L136))

## How
In this change, we make the read operation to return the current version in `Version` response header. Then the caller need to provide this `Version` header in the request for write operstions. For example:

```
./quotaservice-cli show app:traffic-exemplar xzhu_test --env staging                   
** Current version: 3538
{"name":"xzhu_test","namespace":"app:traffic-exemplar","size":1,"fill_rate":1,"wait_timeout_millis":1,"max_idle_millis":-1,"max_debt_millis":10000,"max_tokens_per_request":1}

./quotaservice-cli update app:traffic-exemplar xzhu_test --env staging --debug -f quota-envoy.config -v 3538
```


