### PR TITLE
Admin endpoint version header optional

### DIFF
--- a/admin/admin.go
+++ b/admin/admin.go
@@ -116,7 +116,7 @@ func apiVersionHandler(a Administrable, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		versionHeader := r.Header.Get("Version")
 
-		if r.Method == http.MethodGet && versionHeader == "" {
+		if versionHeader == "" {
 			next.ServeHTTP(w, r)
 			return
 		}

--- a/admin/admin_test.go
+++ b/admin/admin_test.go
@@ -31,8 +31,8 @@ func TestNamespacesPostNoVersion(t *testing.T) {
 	defer ts.Close()
 	jsonResponse := executeRequestForVersioningTest(ts, false, http.MethodPost, "", t)
 
-	if jsonResponse["error"] != http.StatusText(http.StatusBadRequest) {
-		t.Errorf("Expected 400 Bad Request, but received \"%+v\"", jsonResponse)
+	if jsonResponse["error"] != "" {
+		t.Errorf("POST request without version header should succeed \"%+v\"", jsonResponse)
 	}
 }
 


### PR DESCRIPTION
## What
This allows the `quotaservice-cli` to add/update/delete namespace/bucket config.

The write operations (add/update/delete) needs a `Version` header in the request, and require the version to match the current config version, to achieve optimistic update. Without this header, the write operation will fail ([here](https://github.com/square/quotaservice/blob/44c0db092cd1dcf7999d5df1d5c0e11a4cd2b0ec/admin/admin.go#L119-L136))

## How
Make the `Version` header optional. This will make the latest change to always stored, regardless of the current value. This is not a regression to how Square currently use quotaservice, as Square Console is doing the same. But ideally, this is not great. so here's alternative solution: https://github.com/square/quotaservice/pull/206